### PR TITLE
fix: TextButton 컴포넌트 수정

### DIFF
--- a/client/src/components/TextButton.tsx
+++ b/client/src/components/TextButton.tsx
@@ -4,11 +4,12 @@ interface ButtonProps {
   width: string | number;
   size: 'large' | 'small';
   backgroundColor: string;
+  disabledBackgroundColor?: string;
 }
 
 interface TextButtonProps extends ButtonProps {
   type?: 'button' | 'submit' | 'reset';
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;
   children: string;
 }
@@ -36,7 +37,8 @@ const StyledButton = styled.button<ButtonProps>`
   cursor: pointer;
 
   &[disabled] {
-    background: var(--color-grey);
+    background: ${({ disabledBackgroundColor }) =>
+      disabledBackgroundColor ?? 'var(--color-grey)'};
   }
 `;
 
@@ -47,6 +49,7 @@ export default function TextButton({
   width,
   size,
   backgroundColor,
+  disabledBackgroundColor,
   children,
 }: TextButtonProps) {
   return (
@@ -56,6 +59,7 @@ export default function TextButton({
       width={width}
       size={size}
       backgroundColor={backgroundColor}
+      disabledBackgroundColor={disabledBackgroundColor}
       disabled={disabled}
     >
       {children}


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] style
- [ ] resource
- [ ] chore
<br>

### 2️⃣ 이슈 번호
ex) close #74 
<br>
<br>

### 3️⃣ 변경 사항
- onClick 프로퍼티를 사용하지 않는 type='submit'인 버튼을 사용하기 위해서 onClick props를 필수가 아닌 optional로 설정
- 버튼이 diabled 상태가 됐을 때, 버튼의 색을 회색으로만 고정하는 것이 아니고, 사용자가 지정할 수 있도록 disabledBackgroundColor props 설정
<br>
<br>
