### PR TITLE
feat: ErrorMessage 컴포넌트 구현

### DIFF
--- a/client/src/components/ErrorMessage.tsx
+++ b/client/src/components/ErrorMessage.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+
+interface Ierror {
+  [key: string]: string;
+}
+
+interface Itouched {
+  [key: string]: boolean;
+}
+
+interface IErrorMessage {
+  name: string;
+  touched: Itouched;
+  errors: Ierror;
+  isDuplicated?: boolean | null;
+  serverError?: boolean;
+  style: { color: string; bottom?: string };
+}
+const FormErrorMessage = styled.div<{
+  style: { color: string; bottom?: string };
+}>`
+  width: 100%;
+  position: absolute;
+  font-size: var(--text-xs);
+  ${({ style }) => (style.bottom ? '' : 'top : 4.25rem')}; // 68px
+  left: var(--spacing-sm);
+  bottom: ${({ style }) => style.bottom}; // 112px;  // 로그인
+  color: var(${({ style }) => style.color}); // #F13E1F;
+`;
+
+export default function ErrorMessage({
+  name,
+  touched,
+  errors,
+  isDuplicated,
+  serverError,
+  style,
+}: IErrorMessage) {
+  if (serverError)
+    return (
+      <FormErrorMessage style={style}>
+        일치하는 회원 정보가 없어요. 다시 시도해주세요.
+      </FormErrorMessage>
+    );
+  if (isDuplicated === undefined || isDuplicated === null) {
+    if (!touched[name] || !errors[name]) {
+      return null;
+    }
+    return <FormErrorMessage style={style}>{errors[name]}</FormErrorMessage>;
+  }
+  // 중복 체크
+  if (!isDuplicated) style.color = '--color-normal-green';
+  return (
+    <FormErrorMessage style={style}>
+      {isDuplicated
+        ? '이미 존재하는 아이디입니다.'
+        : '사용 가능한 아이디입니다.'}
+    </FormErrorMessage>
+  );
+}

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -11,6 +11,7 @@ import FooterImg from './FooterImg';
 import Form from './Form';
 import InputContainer from './InputContainer';
 import Input from './Input';
+import ErrorMessage from './ErrorMessage';
 
 export {
   MoneyInfo,
@@ -26,4 +27,5 @@ export {
   Form,
   InputContainer,
   Input,
+  ErrorMessage,
 };


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] style
- [ ] resource
- [ ] chore
<br>

### 2️⃣ 이슈 번호
ex) close #84 
<br>
<br>

### 3️⃣ 변경 사항
- props로 name, touched, errors, isDuplicated, serverError, style을 받는다
  	- name: input의 name이다. name을 키로 활용하여 touched, errors 객체에서 해당하는 인풋의 값을 가져온다.
	- touced : 각 input이 onBlur 됐는지 유무를 갖는 객체
	- errors : 각 input의 에러메세지. validation을 통과했다면 빈문자열을 값으로 갖는다.
	- isDuplicated : 서버에 중복확인 요청을 보내서 받아오는 값으로써 해당 인풋의 값이 디비에 있는지 유무
	- serverError : onSubmit으로 서버에 요청을 보냈을 때, 실패했을 경우 나타내는 에러메세지를 위한 불리언값
	- style : 에러메세지의 스타일. color와 bottom이 있다.
- 서버에러, 중복, validate 통과 유무, 인풋이 touched됐는지 유무를 통해서 에러메시지를 나타낸다
<br>
<br>
