### PR TITLE
fix: 중복확인 초기화 버그 수정

### DIFF
--- a/client/src/hooks/useForm.ts
+++ b/client/src/hooks/useForm.ts
@@ -14,7 +14,7 @@ interface Itouched {
 
 interface IuseForm {
   initialValues: IinitialValues;
-  validate: (values: IinitialValues) => Ierror;
+  validate: (values: IinitialValues, currentInput: string) => Ierror;
   onSubmit: (values: IinitialValues) => void;
 }
 
@@ -22,12 +22,14 @@ export const useForm = ({ initialValues, validate, onSubmit }: IuseForm) => {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState<Ierror>({});
   const [touched, setTouched] = useState<Itouched>({});
+  const [currentInput, setCurrentInput] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValues({
       ...values,
       [e.target.name]: e.target.value,
     });
+    setCurrentInput(e.target.name);
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
@@ -42,7 +44,10 @@ export const useForm = ({ initialValues, validate, onSubmit }: IuseForm) => {
     onSubmit(values);
   };
 
-  const runValidator = useCallback(() => validate(values), [values]);
+  const runValidator = useCallback(
+    () => validate(values, currentInput),
+    [values]
+  );
 
   const getFieldProps = (name: string) => {
     const value = values[name];

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -48,7 +48,7 @@ export default function SignUp() {
   const { values, errors, touched, handleSubmit, getFieldProps, isValid } =
     useForm({
       initialValues: { id: '', nickname: '', password: '', pwcheck: '' },
-      validate: (values) => {
+      validate: (values, currentInput) => {
         const errors = {
           id: '',
           nickname: '',
@@ -67,7 +67,7 @@ export default function SignUp() {
         if (values.password !== values.pwcheck) {
           errors.pwcheck = '비밀번호가 일치하지 않아요.';
         }
-        setIsDuplicated(null);
+        if (currentInput === 'id') setIsDuplicated(null);
         return errors;
       },
       onSubmit: async (values) => {
@@ -106,7 +106,10 @@ export default function SignUp() {
   };
   const getSVGColor = (content: string) =>
     content === '' ? '#CDCDCD' : '#01192C'; // 유틸로
-  const isCompValid = () => isDuplicated === false && isValid();
+  const isCompValid = () => {
+    console.log('isDuplicated : ', isDuplicated);
+    return isDuplicated === false && isValid();
+  };
   return (
     <>
       <FormContainer>


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] style
- [ ] resource
- [ ] chore
<br>

### 2️⃣ 이슈 번호
ex) close #101
<br>
<br>

### 3️⃣ 변경 사항
- 중복확인하는 input 컴포넌트 외의 input 컴포넌트가 변경되어도 중복확인이 초기화되는 버그 수정
- 기존 useForm에서는 onChange 이벤트가 발생하면 모든 values에 대해 validate를 진행했음
- validate 진행시 어떤 input 컴포넌트가 변경되었는지 알 수 있게 currentInput state를 만들어서 인자로 전달
- validate 함수 내부에서 중복확인하는 input 컴포넌트가 변경되었을 경우에만 중복확인 초기화 진행
<br>
<br>

