### PR TITLE
feat: vegi 페이지 설정한 시간에 칭찬 버튼 활성화 기능 구현

### DIFF
--- a/client/src/pages/VegiPage/components/DictButton.tsx
+++ b/client/src/pages/VegiPage/components/DictButton.tsx
@@ -87,7 +87,7 @@ export default function DictButton({
 
   return (
     <ButtonContainer>
-      <Button onClick={handleButtonClick} disabled={isDisabled}>
+      <Button onClick={handleButtonClick} disabled={isDisabled || listening}>
         <Img src={listening ? getAsset('micon.svg') : getAsset('micoff.svg')} />
         {children}
       </Button>


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] style
- [ ] resource
- [ ] chore
<br>

### 2️⃣ 이슈 번호
ex) close #108
<br>
<br>

### 3️⃣ 변경 사항
- 음성인식 중 칭찬하기 버튼 못 누르도록 비활성화 - DictButton 컴포넌트에서 disabled로직을 isDiabled || listening으로 변경

- 시간 설정 안 되어 있을 때 vegi페이지 칭찬하기 버튼 비활성화
	- alarm === '' :  alarm state를 통해서 구분

- 현재  시간과 알람 시간 비교해서 전후 1분만 칭찬하기 버튼 활성화, 그 외의  시간에는 칭찬하기 버튼 비활성화
	- executeFuncOnTime 유틸 함수를 사용하여 지정한 시간 1분간 활성화

- 칭찬  완료한 날에는 하루동안 칭찬하기 버튼 비활성화
	- 유저 정보 받아올 때, isCompleted를 받아와서 오늘 칭찬항 야채인지 구분
<br>
<br>
