### PR TITLE
fix: 알람시간 zero padding 처리

### DIFF
--- a/client/src/utils/executeFuncOnTime.ts
+++ b/client/src/utils/executeFuncOnTime.ts
@@ -6,8 +6,7 @@ export function executeFuncOnTime(
   const year = date.getFullYear(); // 2021
   const month = date.getMonth();
   const day = date.getDate(); // 10
-  date.getHours();
-  date.getMinutes();
+
   const oprDate = new Date(year, month, day, hour, minute);
   const nowDate = new Date();
 

--- a/client/src/utils/getDefaultAlarmFormat.ts
+++ b/client/src/utils/getDefaultAlarmFormat.ts
@@ -33,7 +33,9 @@ export const separateAlarmFormat = (datestr: string): Alarm => {
 };
 
 export const getAlarmFormat = ({ hour, minute, ampm }: Alarm) => {
-  return `${ampm} ${hour}:${minute}`;
+  const hourStr = hour.toString();
+  const minuteStr = minute.toString().padStart(2, '0');
+  return `${ampm} ${hourStr}:${minuteStr}`;
 };
 
 export const getAlarmTime = ({ hour, minute, ampm }: Alarm) => ({


### PR DESCRIPTION
### 1️⃣ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] style
- [ ] resource
- [ ] chore
<br>

### 2️⃣ 이슈 번호
X

### 3️⃣ 변경 사항
- 기존에 minute이 1자리 수일 경우 'AM 1:1'로 화면에 나타났던 것을 zero padding 처리를 통하여 'AM 1:01'로 나타나게 수정<br>

### 4️⃣ 테스트 결과
![20230304052608](https://user-images.githubusercontent.com/65334125/222822223-bb1c732c-f7ce-410e-8630-7a7fad0f8d96.png)

